### PR TITLE
fix(adapters): Give liquid's config an initial value.

### DIFF
--- a/lib/adapters/liquid.adapter.ts
+++ b/lib/adapters/liquid.adapter.ts
@@ -8,7 +8,7 @@ import { TemplateAdapter } from '../interfaces/template-adapter.interface';
 import { Liquid } from 'liquidjs';
 
 export class LiquidAdapter implements TemplateAdapter {
-	private config: Partial<Liquid['options']>;
+	private config: Partial<Liquid['options']> = {};
 
 	constructor(config?: Partial<Liquid['options']>) {
 		Object.assign(this.config, config);


### PR DESCRIPTION
The reason for doing this is to fix: [#1232](https://github.com/nest-modules/mailer/issues/1232):

> Using LiquidAdapter() won't work in the MailerModule.forRoot() method.
> ```
> /test-project/node_modules/@nestjs-modules/mailer/dist/adapters/liquid.adapter.js:9
>         Object.assign(this.config, config);
>               ^
>
> TypeError: Cannot convert undefined or null to object
>    at Function.assign (<anonymous>)
>    at new LiquidAdapter (/test-project/node_modules/@nestjs-modules/mailer/dist/adapters/liquid.adapter.js:9:16)
>    at Object.<anonymous> (/test-project/src/app.module.ts:12:18)
>    at Module._compile (node:internal/modules/cjs/loader:1358:14)
>    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
>    at Module.load (node:internal/modules/cjs/loader:1208:32)
>    at Module._load (node:internal/modules/cjs/loader:1024:12)
>    at Module.require (node:internal/modules/cjs/loader:1233:19)
>    at require (node:internal/modules/helpers:179:18)
>    at Object.<anonymous> (/test-project/src/main.ts:2:1)
> ```

Note: When using the liquid adapter in NestJS, you must add the template's directory to `assets` in `nest-cli.json`, otherwise the template will not be carried into the dist.